### PR TITLE
Corrected beakerbrowser hyperlinks

### DIFF
--- a/index.html
+++ b/index.html
@@ -60,7 +60,7 @@
         </div>
         <p>
           <strong>Spork</strong> is a command-line tool for <a href="https://github.com/hyperswarm/dht" title="Hyperswarm peer-to-peer network">peer-to-peer sockets</a>
-          created by the people behind <a href="https://beaker-browser.com" title="Beaker Browser">Beaker Browser</a>
+          created by the people behind <a href="https://beakerbrowser.com" title="Beaker Browser">Beaker Browser</a>
           and part of the new <a href="https://atek.cloud" title="Atek Cloud">Atek Cloud project</a>.
           <strong>Self host your life!</strong>
         </p>
@@ -154,7 +154,7 @@ Spork powers ACTIVATED
         <p>
           <strong>Spork</strong> is a part of the <a href="https://atek.cloud" title="Atek Cloud">Atek Cloud</a> mission to self-host our lives.
           We're channeling the deep magics of the <a href="https://hypercore-protocol.org" title="Hypercore Protocol">Hypercore Protocol</a>.
-          Atek and Spork were built by the same people behind <a href="https://beaker-browser.com" title="Beaker Browser">Beaker Browser</a>.
+          Atek and Spork were built by the same people behind <a href="https://beakerbrowser.com" title="Beaker Browser">Beaker Browser</a>.
         </p>
       </main>
     </div>


### PR DESCRIPTION
Beaker browser website does not have a hyphen in it.
beaker-browser.com (wrong) -> beakerbrowser.com (correct)